### PR TITLE
Display blog series, date, and read times

### DIFF
--- a/src/pages/blogs/[blog].astro
+++ b/src/pages/blogs/[blog].astro
@@ -24,6 +24,10 @@ const title =
 const autoSummary = generateAutoSummary(blog.body || "", blog.data.summary);
 
 const { Content } = await render(blog);
+
+// Determine series name from subdirectory (exclude 'archive')
+const seriesName = blog.id.includes("/") ? blog.id.split("/")[0] : undefined;
+const showSeries = seriesName && seriesName.toLowerCase() !== "archive";
 ---
 
 <ContentLayout title={title} summary={autoSummary}>
@@ -38,6 +42,11 @@ const { Content } = await render(blog);
     <div
       class="items-center w-full justify-evenly flex gap-x-5 text-sm text-zinc-400"
     >
+      {showSeries && (
+        <p class="text-balance" transition:name={`${title} series`}>
+          Series: {seriesName}
+        </p>
+      )}
       <p class="text-balance" transition:name={`${title} published`}>
         Published: {blog.data.published?.toUTCString().slice(0, -13)}
       </p>


### PR DESCRIPTION
Add series detection and display to blog posts based on subdirectory, shown alongside published date and read times.

---
<a href="https://cursor.com/background-agent?bcId=bc-9cbb912b-3b56-49c3-b535-cd58bc444ebb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9cbb912b-3b56-49c3-b535-cd58bc444ebb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

